### PR TITLE
remove codesponsor

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,9 +31,7 @@
 
 ## Sponsors
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/JHiroABWV9N5QKgcFuTA2NxX/laradock/laradock'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/JHiroABWV9N5QKgcFuTA2NxX/laradock/laradock.svg' />
-</a>
+
 
 ## Contributors
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8